### PR TITLE
fix: seurat environment in qmd

### DIFF
--- a/labs/seurat/seurat_01_qc.qmd
+++ b/labs/seurat/seurat_01_qc.qmd
@@ -58,7 +58,11 @@ suppressPackageStartupMessages({
     library(Matrix)
     library(ggplot2)
     library(patchwork)
-    # remotes::install_github("chris-mcginnis-ucsf/DoubletFinder", upgrade = FALSE, dependencies = TRUE)
+    remotes::install_github(
+        "https://github.com/chris-mcginnis-ucsf/DoubletFinder@3b420df68b8e2a0cc6ebd4c5c1c7ea170464c97f",
+        upgrade = FALSE,
+        dependencies = FALSE
+    )
     library(DoubletFinder)
 })
 ```

--- a/labs/seurat/seurat_02_dimred.qmd
+++ b/labs/seurat/seurat_02_dimred.qmd
@@ -16,9 +16,6 @@ Code chunks run R commands unless otherwise specified.
 ```{r}
 #| label: libraries
 
-# Activate conda environment to get the correct python path
-reticulate::use_condaenv("/Users/asabjor/miniconda3/envs/seurat5", required = TRUE)
-
 suppressPackageStartupMessages({
     library(Seurat)
     library(ggplot2) # plotting

--- a/labs/seurat/seurat_03_integration.qmd
+++ b/labs/seurat/seurat_03_integration.qmd
@@ -33,7 +33,7 @@ suppressPackageStartupMessages({
     library(basilisk)
 })
 
-condapath = "/Users/asabjor/miniconda3/envs/seurat5_u"
+condapath = "/usr/local/conda/envs/seurat"
 ```
 
 ```{r}

--- a/labs/seurat/seurat_06_celltyping.qmd
+++ b/labs/seurat/seurat_06_celltyping.qmd
@@ -29,7 +29,27 @@ suppressPackageStartupMessages({
     library(scPred)
     library(celldex)
     library(SingleR)
+    library(remotes)
+    remotes::install_github(
+        "https://github.com/satijalab/seurat-data@4dc08e022f51c324bc7bf785b1b5771d2742701d",
+        upgrade = FALSE,
+        dependencies = FALSE
+    )
     library(SeuratData)
+    remotes::install_github(
+        "https://github.com/immunogenomics/presto@7636b3d0465c468c35853f82f1717d3a64b3c8f6",
+        upgrade = FALSE,
+        dependencies = FALSE
+    )
+    remotes::install_github(
+        "https://github.com/mojaveazure/seurat-disk@877d4e18ab38c686f5db54f8cd290274ccdbe295",
+        upgrade = FALSE,
+        dependencies = FALSE)
+    remotes::install_github(
+        "https://github.com/satijalab/azimuth@243ee5db80fcbffa3452c944254a325a3da2ef9e",
+        upgrade = FALSE,
+        dependencies = FALSE
+    )
     library(Azimuth)
 })
 ```


### PR DESCRIPTION
This PR includes fixes to the `seurat` labs (`.qmd` files) related to the environment such as:

- fix conda path
- pin R packages installed from GitHub